### PR TITLE
fix xhr url parse exception

### DIFF
--- a/src/proxy/dev/client.js
+++ b/src/proxy/dev/client.js
@@ -68,7 +68,7 @@ const clientHook = () => {
 
     // hook AJAX API
     xhook.before((request) => {
-        let url = new URL(request.url)
+        let url = new URL(request.hasOwnProperty('xhr') ? _proxyOrigin + request.url : url)
         if (url.origin !== _proxyOrigin) {
             request.headers[_proxyTargetKey] = url.origin
             request.url = _proxyOrigin + request.url.slice(url.origin.length)


### PR DESCRIPTION
raise 'ERR_INVALID_URL' exception when parse relative url.

bad case: http://www.bing.com